### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Plugin works with program mode only, and changes to the temperature are treated 
 <!--ts-->
    * [homebridge-warmup4ie](#homebridge-warmup4ie)
    * [Table of Contents](#table-of-contents)
+   * [Tested Warmup thermostats](#tested-warmup-thermostats)
    * [Using the plugin](#using-the-plugin)
       * [Temperature Control](#temperature-control)
       * [Mode Setting](#mode-setting)
@@ -35,9 +36,9 @@ Changes to the temperature create a temperature override for the current setting
 
 ## Mode Setting
 
-`Off` - Turns off the thermostat
-`Heat` - Turns on the thermostat and resumes current program
-`Auto` - Turns on the thermostat and resumes current program
+* `Off` - Turns off the thermostat
+* `Heat` - Turns on the thermostat and resumes current program
+* `Auto` - Turns on the thermostat and resumes current program
 
 When the thermostat is in temperature override mode, the Mode setting is set to `Heat`.  To clear the override and resume program mode, turn the mode control to `Auto`.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # homebridge-warmup4ie
 
-Homebridge plugin for the WarmUP 4iE thermostat.
+Homebridge plugin for the WarmUP 4iE and 6iE thermostat.
 
 Plugin works with program mode only, and changes to the temperature are treated as an override.  Fixed temperature mode is not supported.  
 
@@ -19,6 +19,11 @@ Plugin works with program mode only, and changes to the temperature are treated 
 <!-- Added by: sgracey, at:  -->
 
 <!--te-->
+
+# Tested Warmup thermostats
+
+* Warmup 4iE Smart Wifi Thermostat
+* Warmup 6iE Smart Wifi Thermostat
 
 # Using the plugin
 


### PR DESCRIPTION
Tested to work with 6iE model as well. Suggesting to reflect this in the readme for others.

## :recycle: Current situation

* Currently only 4iE model is mentioned, potentially discouraging owners of other models to try it out.

## :bulb: Proposed solution

* Updating `README.md` to reflect that the plugin also works for 6iE model. (Great work!)

### Testing

* Tested with 1x 6iE model on Homebridge Synology